### PR TITLE
fix cursor position and selection after toggling text edits

### DIFF
--- a/src/ts/formatting.ts
+++ b/src/ts/formatting.ts
@@ -362,7 +362,9 @@ function styleByWrapping(editor: TextEditor, startPattern: string, endPattern?: 
         }
     });
 
-    return editor.applyEdit(batchEdit, newSelections)
+    return editor.applyEdit(batchEdit, newSelections).then(() => {
+        editor.selections = newSelections;
+    });
 }
 
 /**


### PR DESCRIPTION
Here are a problems with toggling style behaviour if there is no editor selection.
The reason is described here https://github.com/microsoft/monaco-editor/issues/1811


### Before
- Cursor doesn't preserve correct position after applying text edits
[
![before_cursor_toggle_on](https://user-images.githubusercontent.com/6134924/87553814-0946af00-c6bc-11ea-8d5b-e4351e933f9f.gif)
](url)

- Unexpected selection if cursor at the end of the line, that leads to incorrect reverse toggling behaviour

![before_cursor_end_toggle_on](https://user-images.githubusercontent.com/6134924/87553937-32673f80-c6bc-11ea-92af-93cd835fd730.gif)

![before_cursor_end_toggle_off](https://user-images.githubusercontent.com/6134924/87553948-34c99980-c6bc-11ea-9284-36f8954f9212.gif)


### After

- Cursor position
![fixed_cursor_toggle_on](https://user-images.githubusercontent.com/6134924/87554069-57f44900-c6bc-11ea-829e-d446381dd48e.gif)
![fixed_cursor_toggle_off](https://user-images.githubusercontent.com/6134924/87554074-59be0c80-c6bc-11ea-9fea-d199504ef2fd.gif)

- Rm unexpected selection

![fixed_cursor_end_toggle_on](https://user-images.githubusercontent.com/6134924/87554121-67739200-c6bc-11ea-88a5-71f3d11d78df.gif)
![fixed_cursor_end_toggle_off](https://user-images.githubusercontent.com/6134924/87554126-6a6e8280-c6bc-11ea-91de-8a29e4b57165.gif)

