### PR TITLE
Fix cursor position only if there wasn't visible selection

### DIFF
--- a/src/ts/formatting.ts
+++ b/src/ts/formatting.ts
@@ -369,8 +369,12 @@ function styleByWrapping(editor: TextEditor, startPattern: string, endPattern?: 
         }
     });
 
+    const hasSelection = editor.selection && !editor.selection.isEmpty;
+
     return editor.applyEdit(batchEdit, newSelections).then(() => {
-        editor.selections = newSelections;
+        if (!hasSelection) {
+            editor.selections = newSelections;
+        }
     });
 }
 


### PR DESCRIPTION
Fix my previous pull request https://github.com/traff/monaco-markdown/pull/3 .
We have to fix cursor position only if there wasn't visible selection, otherwise keeping cursor position is expected behaviour.
